### PR TITLE
utf8 encode credential id

### DIFF
--- a/src/Actions/FindPasskeyToAuthenticateAction.php
+++ b/src/Actions/FindPasskeyToAuthenticateAction.php
@@ -71,7 +71,7 @@ class FindPasskeyToAuthenticateAction
     {
         $passkeyModel = Config::getPassKeyModel();
 
-        return $passkeyModel::firstWhere('credential_id', $publicKeyCredential->rawId);
+        return $passkeyModel::firstWhere('credential_id', utf8_encode($publicKeyCredential->rawId));
     }
 
     protected function determinePublicKeyCredentialSource(

--- a/src/Models/Passkey.php
+++ b/src/Models/Passkey.php
@@ -35,7 +35,7 @@ class Passkey extends Model
                 PublicKeyCredentialSource::class
             ),
             set: fn (PublicKeyCredentialSource $value) => [
-                'credential_id' => $value->publicKeyCredentialId,
+                'credential_id' => utf8_encode($value->publicKeyCredentialId),
                 'data' => $serializer->toJson($value),
             ],
         );


### PR DESCRIPTION
This pull request includes changes to utf8 encode the credential IDs in the `FindPasskeyToAuthenticateAction` and `Passkey` models. 

Fixes #8 