### PR TITLE
Updated deprecated utf8_encode to mb_convert_encoding

### DIFF
--- a/src/Actions/FindPasskeyToAuthenticateAction.php
+++ b/src/Actions/FindPasskeyToAuthenticateAction.php
@@ -71,7 +71,7 @@ class FindPasskeyToAuthenticateAction
     {
         $passkeyModel = Config::getPassKeyModel();
 
-        return $passkeyModel::firstWhere('credential_id', utf8_encode($publicKeyCredential->rawId));
+        return $passkeyModel::firstWhere('credential_id', mb_convert_encoding($publicKeyCredential->rawId, 'UTF-8'));
     }
 
     protected function determinePublicKeyCredentialSource(

--- a/src/Models/Passkey.php
+++ b/src/Models/Passkey.php
@@ -35,7 +35,7 @@ class Passkey extends Model
                 PublicKeyCredentialSource::class
             ),
             set: fn (PublicKeyCredentialSource $value) => [
-                'credential_id' => utf8_encode($value->publicKeyCredentialId),
+                'credential_id' => mb_convert_encoding($value->publicKeyCredentialId, 'UTF-8'),
                 'data' => $serializer->toJson($value),
             ],
         );


### PR DESCRIPTION
The `utf8_encode` function has been deprecated and will be removed in a future version.  A [suggested replacement](https://www.php.net/manual/en/function.utf8-encode.php#refsect1-function.utf8-encode-notes) is `mb_convert_encoding`

Still fixes bug #8 and removes deprecated code introduced by #9 