### PR TITLE
Change Migration to utilise foreignIdFor

### DIFF
--- a/database/migrations/create_passkeys_table.php.stub
+++ b/database/migrations/create_passkeys_table.php.stub
@@ -13,10 +13,10 @@ return new class extends Migration
 
         $authenticatableTableName = (new $authenticatableClass)->getTable();
 
-        Schema::create('passkeys', function (Blueprint $table) use ($authenticatableTableName) {
+        Schema::create('passkeys', function (Blueprint $table) use ($authenticatableTableName,$authenticatableClass) {
             $table->id();
 
-            $table->foreignId('authenticatable_id')->constrained($authenticatableTableName)->cascadeOnDelete();
+            $table->foreignIdFor($authenticatableClass)->constrained()->cascadeOnDelete();
             $table->text('name');
             $table->text('credential_id');
             $table->json('data');

--- a/database/migrations/create_passkeys_table.php.stub
+++ b/database/migrations/create_passkeys_table.php.stub
@@ -15,8 +15,9 @@ return new class extends Migration
 
         Schema::create('passkeys', function (Blueprint $table) use ($authenticatableTableName,$authenticatableClass) {
             $table->id();
+            
+            $table->foreignIdFor($authenticatableClass, 'authenticatable_id')->constrained(table: $authenticatableTableName, indexName: 'passkeys_authenticatable_fk')->cascadeOnDelete();
 
-            $table->foreignIdFor($authenticatableClass)->constrained()->cascadeOnDelete();
             $table->text('name');
             $table->text('credential_id');
             $table->json('data');


### PR DESCRIPTION
In the generated migration, rather than using foreignId, using foreignIdFor allows the Column Type to be generated correctly, allowing for UUID/ULID etc.

The constrained() is also populated correctly.

Without this, anyone using UUID/ULID for their User model, would need to manually edit the generated migration.