### PR TITLE
Add "active" (status) for pass key

### DIFF
--- a/database/migrations/create_passkeys_table.php.stub
+++ b/database/migrations/create_passkeys_table.php.stub
@@ -21,6 +21,7 @@ return new class extends Migration
             $table->text('name');
             $table->text('credential_id');
             $table->json('data');
+            $table->boolean('active')->default(true);
 
             $table->timestamp('last_used_at')->nullable();
             $table->timestamps();

--- a/resources/lang/en/passkeys.php
+++ b/resources/lang/en/passkeys.php
@@ -1,5 +1,7 @@
 <?php
 
 return [
+    'disable' => 'Disable',
+    'enable' => 'Enable',
     'invalid' => 'Could not login using the given passkey',
 ];

--- a/resources/views/livewire/passkeys.blade.php
+++ b/resources/views/livewire/passkeys.blade.php
@@ -27,7 +27,11 @@
                         Last used: {{ $passkey->last_used_at?->diffForHumans() ?? 'Not used yet' }}
                     </div>
 
-
+                    <div>
+                        <button wire:click="togglePasskey({{ $passkey->id}})" class="inline-flex justify-center py-2 px-4 text-sm font-medium text-white bg-amber-600">
+                            {{ $passkey->active ? __('passkeys::passkeys.disable') : __('passkeys::passkeys.enable') }}
+                        </button>
+                    </div>
                     <div>
                         <button wire:click="deletePasskey({{ $passkey->id }})" class="inline-flex justify-center py-2 px-4 text-sm font-medium text-white bg-red-600">
                             Delete

--- a/src/Actions/FindPasskeyToAuthenticateAction.php
+++ b/src/Actions/FindPasskeyToAuthenticateAction.php
@@ -71,7 +71,7 @@ class FindPasskeyToAuthenticateAction
     {
         $passkeyModel = Config::getPassKeyModel();
 
-        return $passkeyModel::firstWhere('credential_id', mb_convert_encoding($publicKeyCredential->rawId, 'UTF-8'));
+        return $passkeyModel::where('credential_id', mb_convert_encoding($publicKeyCredential->rawId, 'UTF-8'))->where('active', true)->first();
     }
 
     protected function determinePublicKeyCredentialSource(

--- a/src/Livewire/PasskeysComponent.php
+++ b/src/Livewire/PasskeysComponent.php
@@ -53,7 +53,7 @@ class PasskeysComponent extends Component
 
         $this->clearForm();
     }
-    
+
     public function togglePasskey(int $passkeyId): void
     {
         try {

--- a/src/Livewire/PasskeysComponent.php
+++ b/src/Livewire/PasskeysComponent.php
@@ -53,6 +53,17 @@ class PasskeysComponent extends Component
 
         $this->clearForm();
     }
+    
+    public function togglePasskey(int $passkeyId): void
+    {
+        try {
+            $passKey = $this->currentUser()->passkeys()->where('id', $passkeyId)->firstOrFail();
+            $passKey->active = ! $passKey->active;
+            $passKey->save();
+        } catch (Throwable $e) {
+            throw $e;
+        }
+    }
 
     public function deletePasskey(int $passkeyId): void
     {

--- a/src/Models/Passkey.php
+++ b/src/Models/Passkey.php
@@ -18,10 +18,25 @@ class Passkey extends Model
 
     protected $guarded = [];
 
+    /**
+     * The model's default values for attributes.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'active' => true,
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
     public function casts(): array
     {
         return [
             'last_used_at' => 'datetime',
+            'active' => 'boolean',
         ];
     }
 


### PR DESCRIPTION
This PR adds:
1) An "active" column to the passkeys table migration (defaulted to true)
2) The "active" attribute (defaulted to true) to the PassKey model
3) A check that the PassKey is "active" when running findPasskey, ensuring that the PassKey is active when authenticating
4) A toggle function, and button to the Livewire PassKeysComponent (and blade)

The logic behind this is that it may be desirable to temporarily disable a PassKey, rather than delete it entirely, for example - when leaving a device out-of-reach temporarily.

Appreciate that this could be achieved by just over-riding the actions, but figured this is core enough that it may be worth including out-of-the-box.  Alternatively, happy to write up a "how-to".

I did notice that tests seem to be failing, but it looks that way historically at the moment (given this is in pre-beta understandably).

