### PR TITLE
Localise Views & Component Output

### DIFF
--- a/resources/lang/en/passkeys.php
+++ b/resources/lang/en/passkeys.php
@@ -1,5 +1,15 @@
 <?php
 
 return [
+    'authenticate_using_passkey' => 'Authenticate using Passkey',
+    'create' => 'Create',
+    'delete' => 'Delete',
+    'error_something_went_wrong_generating_the_passkey' => 'Something went wrong generating the passkey.',
     'invalid' => 'Could not login using the given passkey',
+    'last_used' => 'Last used',
+    'name' => 'Name',
+    'name_placeholder' => 'Enter Passkey Name',
+    'no_passkeys_registered' => 'No passkeys registered',
+    'not_used_yet' => 'Not used yet',
+    'passkeys' => 'Passkeys',
 ];

--- a/resources/views/components/authenticate.blade.php
+++ b/resources/views/components/authenticate.blade.php
@@ -20,7 +20,7 @@
     <div onclick="authenticateWithPasskey()">
         @if ($slot->isEmpty())
             <div class="underline cursor-pointer">
-                Authenticate using Passkey
+                {{ __('passkeys::passkeys.authenticate_using_passkey') }}
             </div>
         @else
             {{ $slot }}

--- a/resources/views/livewire/passkeys.blade.php
+++ b/resources/views/livewire/passkeys.blade.php
@@ -1,9 +1,9 @@
 <div>
-    <h1>Passkeys</h1>
+    <h1>{{ __('passkeys::passkeys.passkeys') }}</h1>
     <div class="mt-2">
         <form id="passkeyForm" wire:submit="validatePasskeyProperties" class="flex items-center space-x-2">
             <div>
-                <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+                <label for="name" class="block text-sm font-medium text-gray-700">{{ __('passkeys::passkeys.name') }}</label>
                 <input autocomplete="off" type="text" wire:model="name" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
                 @error('name')
                 <span class="text-red-500 text-sm">{{ $message }}</span>
@@ -11,7 +11,7 @@
             </div>
 
             <button type="submit" class="mt-6 inline-flex justify-center py-2 px-4 font-medium">
-                Create
+                {{ __('passkeys::passkeys.create') }}
             </button>
         </form>
     </div>
@@ -24,13 +24,13 @@
                         {{ $passkey->name }}
                     </div>
                     <div class="ml-2">
-                        Last used: {{ $passkey->last_used_at?->diffForHumans() ?? 'Not used yet' }}
+                        {{ __('passkeys::passkeys.last_used') }}: {{ $passkey->last_used_at?->diffForHumans() ?? __('passkeys::passkeys.not_used_yet') }}
                     </div>
 
 
                     <div>
                         <button wire:click="deletePasskey({{ $passkey->id }})" class="inline-flex justify-center py-2 px-4 text-sm font-medium text-white bg-red-600">
-                            Delete
+                            {{ __('passkeys::passkeys.delete') }}
                         </button>
                     </div>
                 </li>

--- a/src/Livewire/PasskeysComponent.php
+++ b/src/Livewire/PasskeysComponent.php
@@ -27,6 +27,8 @@ class PasskeysComponent extends Component
 
     public function validatePasskeyProperties(): void
     {
+        $this->validate();
+
         $this->dispatch('passkeyPropertiesValidated', [
             'passkeyOptions' => json_decode($this->generatePasskeyOptions()),
         ]);
@@ -47,7 +49,7 @@ class PasskeysComponent extends Component
         } catch (Throwable $e) {
             throw $e;
             throw ValidationException::withMessages([
-                'name' => 'Something went wrong generating the passkey.',
+                'name' => __('passkeys::passkeys.error_something_went_wrong_generating_the_passkey'),
             ])->errorBag('passkeyForm');
         }
 


### PR DESCRIPTION
Very minor PR, this:

1) Replaces English strings with a string from the lang/localisation file.
2) Adds a call to validate() for validatePasskeyProperties() so that the Livewire Validation rules run

There will be another few PRs this weekend (if acceptable) which should be:
PR 2) Modifying the view for the Livewire Component
- Make the "Create New Passkey" section responsive
- Migrates the "Existing Keys" into a table  (in it's own view) to make it smoother for extending/modifying when publishing the views

PR 3) Migrate the _"resources/views/livewire/partials/createScript.blade.php"_ code into an x-data element within _"resources/views/livewire/passkeys.blade.php"_  to make it smoother when using wire:navigate, and avoiding potential for duplicating listeners

PR 4) Validates that the browser supports WebAuthn before showing the "Login with PassKey" link
