### PR TITLE
Add AuthenticateUsingPasskeysRequest to PasskeyUsedToAuthenticateEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ To customize where the user is redirected after a successful login, you can pass
 
 ### Events
 
-The package fires the `Spatie\LaravelPasskeys\Events\PasskeyUsedToAuthenticateEvent` when a passkey is used to authenticate. It has a property `passkey` that contains the `Passkey` model that was used to authenticate, and `headers` which contains the request headers that were used to authenticate.
+The package fires the `Spatie\LaravelPasskeys\Events\PasskeyUsedToAuthenticateEvent` when a passkey is used to authenticate. It has a property `passkey` that contains the `Passkey` model that was used to authenticate, and `request` which contains the AuthenticateUsingPasskeysRequest.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ To customize where the user is redirected after a successful login, you can pass
 
 ### Events
 
-The package fires the `Spatie\LaravelPasskeys\Events\PasskeyUsedToAuthenticateEvent` when a passkey is used to authenticate. It has a property `passkey` that contains the `Passkey` model that was used to authenticate.
+The package fires the `Spatie\LaravelPasskeys\Events\PasskeyUsedToAuthenticateEvent` when a passkey is used to authenticate. It has a property `passkey` that contains the `Passkey` model that was used to authenticate, and `headers` which contains the request headers that were used to authenticate.
 
 ## Testing
 

--- a/src/Events/PasskeyUsedToAuthenticateEvent.php
+++ b/src/Events/PasskeyUsedToAuthenticateEvent.php
@@ -8,5 +8,6 @@ class PasskeyUsedToAuthenticateEvent
 {
     public function __construct(
         public Passkey $passkey,
+        public array $headers,
     ) {}
 }

--- a/src/Events/PasskeyUsedToAuthenticateEvent.php
+++ b/src/Events/PasskeyUsedToAuthenticateEvent.php
@@ -3,11 +3,12 @@
 namespace Spatie\LaravelPasskeys\Events;
 
 use Spatie\LaravelPasskeys\Models\Passkey;
+use Spatie\LaravelPasskeys\Http\Requests\AuthenticateUsingPasskeysRequest;
 
 class PasskeyUsedToAuthenticateEvent
 {
     public function __construct(
         public Passkey $passkey,
-        public array $headers,
+        public AuthenticateUsingPasskeysRequest $request,
     ) {}
 }

--- a/src/Events/PasskeyUsedToAuthenticateEvent.php
+++ b/src/Events/PasskeyUsedToAuthenticateEvent.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\LaravelPasskeys\Events;
 
-use Spatie\LaravelPasskeys\Models\Passkey;
 use Spatie\LaravelPasskeys\Http\Requests\AuthenticateUsingPasskeysRequest;
+use Spatie\LaravelPasskeys\Models\Passkey;
 
 class PasskeyUsedToAuthenticateEvent
 {

--- a/src/Http/Controllers/AuthenticateUsingPasskeyController.php
+++ b/src/Http/Controllers/AuthenticateUsingPasskeyController.php
@@ -40,7 +40,7 @@ class AuthenticateUsingPasskeyController
 
         $this->logInAuthenticatable($authenticatable);
 
-        event(new PasskeyUsedToAuthenticateEvent($passkey));
+        event(new PasskeyUsedToAuthenticateEvent($passkey, $request->header()));
 
         return $this->validPasskeyResponse($request);
     }

--- a/src/Http/Controllers/AuthenticateUsingPasskeyController.php
+++ b/src/Http/Controllers/AuthenticateUsingPasskeyController.php
@@ -46,13 +46,6 @@ class AuthenticateUsingPasskeyController
         return $this->validPasskeyResponse($request);
     }
 
-    protected function firePasskeyEvent(Passkey $passkey, AuthenticateUsingPasskeysRequest $request): self
-    {
-        event(new PasskeyUsedToAuthenticateEvent($passkey, $request));
-
-        return $this;
-    }
-
     public function logInAuthenticatable(Authenticatable $authenticatable): self
     {
         auth()->login($authenticatable);
@@ -76,5 +69,12 @@ class AuthenticateUsingPasskeyController
         session()->flash('authenticatePasskey::message', __('passkeys::passkeys.invalid'));
 
         return back();
+    }
+
+    protected function firePasskeyEvent(Passkey $passkey, AuthenticateUsingPasskeysRequest $request): self
+    {
+        event(new PasskeyUsedToAuthenticateEvent($passkey, $request));
+
+        return $this;
     }
 }

--- a/src/Http/Controllers/AuthenticateUsingPasskeyController.php
+++ b/src/Http/Controllers/AuthenticateUsingPasskeyController.php
@@ -53,7 +53,6 @@ class AuthenticateUsingPasskeyController
         return $this;
     }
 
-
     public function logInAuthenticatable(Authenticatable $authenticatable): self
     {
         auth()->login($authenticatable);

--- a/src/Http/Controllers/AuthenticateUsingPasskeyController.php
+++ b/src/Http/Controllers/AuthenticateUsingPasskeyController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Session;
 use Spatie\LaravelPasskeys\Actions\FindPasskeyToAuthenticateAction;
 use Spatie\LaravelPasskeys\Events\PasskeyUsedToAuthenticateEvent;
 use Spatie\LaravelPasskeys\Http\Requests\AuthenticateUsingPasskeysRequest;
+use Spatie\LaravelPasskeys\Models\Passkey;
 use Spatie\LaravelPasskeys\Support\Config;
 
 class AuthenticateUsingPasskeyController
@@ -40,10 +41,18 @@ class AuthenticateUsingPasskeyController
 
         $this->logInAuthenticatable($authenticatable);
 
-        event(new PasskeyUsedToAuthenticateEvent($passkey, $request->header()));
+        $this->firePasskeyEvent($passkey, $request);
 
         return $this->validPasskeyResponse($request);
     }
+
+    protected function firePasskeyEvent(Passkey $passkey, AuthenticateUsingPasskeysRequest $request): self
+    {
+        event(new PasskeyUsedToAuthenticateEvent($passkey, $request));
+
+        return $this;
+    }
+
 
     public function logInAuthenticatable(Authenticatable $authenticatable): self
     {


### PR DESCRIPTION
This PR adds the AuthenticateUsingPasskeysRequest to the PasskeyUsedToAuthenticateEvent, which is fired upon successful authentication.

The purpose of this, is to allow developers to listen for that event, and utilise it as they see fit, for example - checking the the headers, looking for geographic anomalies, identifying commonalities with user agents etc. 

At present, the full request is passed across, as it would seem unreasonable to filter them, as the responsibility for this should fall to the developer using the package.

It also separates the event firing into it's own protected method, the reason for this, is to allow developers to extend the controller more smoothly, and add in any extra logic they wish.

README is also updated to reference this.