### PR TITLE
 AuthenticateUsingPasskeyController internal method visibility

### DIFF
--- a/src/Http/Controllers/AuthenticateUsingPasskeyController.php
+++ b/src/Http/Controllers/AuthenticateUsingPasskeyController.php
@@ -45,7 +45,7 @@ class AuthenticateUsingPasskeyController
         return $this->validPasskeyResponse($request);
     }
 
-    public function logInAuthenticatable(Authenticatable $authenticatable): self
+    protected function logInAuthenticatable(Authenticatable $authenticatable): self
     {
         auth()->login($authenticatable);
 
@@ -54,7 +54,7 @@ class AuthenticateUsingPasskeyController
         return $this;
     }
 
-    public function validPasskeyResponse(Request $request): RedirectResponse
+    protected function validPasskeyResponse(Request $request): RedirectResponse
     {
         $url = Session::has('passkeys.redirect')
             ? Session::pull('passkeys.redirect')


### PR DESCRIPTION
This simply changes the visibility of the following methods to Protected instead of Public:
- logInAuthenticatable
- validPasskeyResponse

This is to ensure that they're only called internally by the Controller, and protects against mistakes by developers.