### PR TITLE
Check If Livewire Exists Before Component Registration

### DIFF
--- a/src/LaravelPasskeysServiceProvider.php
+++ b/src/LaravelPasskeysServiceProvider.php
@@ -50,10 +50,10 @@ class LaravelPasskeysServiceProvider extends PackageServiceProvider
     {
         Blade::component('authenticate-passkey', AuthenticatePasskeyComponent::class);
 
-        if (class_exists(\Livewire\Livewire::class))
-        {
+        if (class_exists(\Livewire\Livewire::class)) {
             \Livewire\Livewire::component('passkeys', PasskeysComponent::class);
         }
+
         return $this;
     }
 }

--- a/src/LaravelPasskeysServiceProvider.php
+++ b/src/LaravelPasskeysServiceProvider.php
@@ -4,7 +4,6 @@ namespace Spatie\LaravelPasskeys;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
-use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LaravelPasskeys\Http\Components\AuthenticatePasskeyComponent;
@@ -51,8 +50,10 @@ class LaravelPasskeysServiceProvider extends PackageServiceProvider
     {
         Blade::component('authenticate-passkey', AuthenticatePasskeyComponent::class);
 
-        Livewire::component('passkeys', PasskeysComponent::class);
-
+        if (class_exists(\Livewire\Livewire::class))
+        {
+            \Livewire\Livewire::component('passkeys', PasskeysComponent::class);
+        }
         return $this;
     }
 }

--- a/src/LaravelPasskeysServiceProvider.php
+++ b/src/LaravelPasskeysServiceProvider.php
@@ -9,7 +9,6 @@ use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LaravelPasskeys\Http\Components\AuthenticatePasskeyComponent;
 use Spatie\LaravelPasskeys\Http\Controllers\AuthenticateUsingPasskeyController;
 use Spatie\LaravelPasskeys\Http\Controllers\GeneratePasskeyAuthenticationOptionsController;
-use Spatie\LaravelPasskeys\Livewire\PasskeysComponent;
 
 class LaravelPasskeysServiceProvider extends PackageServiceProvider
 {
@@ -50,10 +49,10 @@ class LaravelPasskeysServiceProvider extends PackageServiceProvider
     {
         Blade::component('authenticate-passkey', AuthenticatePasskeyComponent::class);
 
-        if (class_exists(\Livewire\Livewire::class)) {
-            \Livewire\Livewire::component('passkeys', PasskeysComponent::class);
+        if (class_exists(\Livewire\Livewire::class))
+        {
+            \Livewire\Livewire::component('passkeys', \Spatie\LaravelPasskeys\Livewire\PasskeysComponent::class);
         }
-
         return $this;
     }
 }

--- a/src/LaravelPasskeysServiceProvider.php
+++ b/src/LaravelPasskeysServiceProvider.php
@@ -49,10 +49,10 @@ class LaravelPasskeysServiceProvider extends PackageServiceProvider
     {
         Blade::component('authenticate-passkey', AuthenticatePasskeyComponent::class);
 
-        if (class_exists(\Livewire\Livewire::class))
-        {
+        if (class_exists(\Livewire\Livewire::class)) {
             \Livewire\Livewire::component('passkeys', \Spatie\LaravelPasskeys\Livewire\PasskeysComponent::class);
         }
+
         return $this;
     }
 }


### PR DESCRIPTION
This checks for Livewire class presence prior to attempting to register the component, removing the requirement for Livewire to be present.

Removes the namespace declarations for Livewire and PasskeysComponent

Replaces
```
        Livewire::component('passkeys', PasskeysComponent::class);
```
With
```
        if (class_exists(\Livewire\Livewire::class))
        {
            \Livewire\Livewire::component('passkeys', \Spatie\LaravelPasskeys\Livewire\PasskeysComponent::class);
        }
```

To ensure that it will only attempt to register the component, if Livewire class is detected (thus Livewire is present).

I did consider using the approach of Composer Versions and detection that way, but figured this was more efficient.