### PR TITLE
Change test suite name to "Spatie Laravel Passkeys Test Suite"

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
     backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="Spatie Test Suite">
+        <testsuite name="Spatie Laravel Passkeys Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
This just changes the testsuite name from "Spatie Test Suite" to  "Spatie Laravel Passkeys Test Suite" so that it identifies the test suite more clearly.