### PR TITLE
Minor adjustment to  authenticateWithPasskey

### DIFF
--- a/resources/views/components/partials/authenticateScript.blade.php
+++ b/resources/views/components/partials/authenticateScript.blade.php
@@ -1,10 +1,8 @@
 <script>
     async function authenticateWithPasskey() {
-        const response = await fetch('{{ route('passkeys.authentication_options') }}')
+        const authenticationOptions = await fetch('{{ route('passkeys.authentication_options') }}').then((response) => response.json());
 
-        const options = await response.json();
-
-        const startAuthenticationResponse = await startAuthentication(options);
+        const startAuthenticationResponse = await startAuthentication({ optionsJSON: authenticationOptions,  });
 
         const form = document.getElementById('passkey-login-form');
 


### PR DESCRIPTION
This PR is to standardise/simplify the JS.

- Simplifies the call for authenticationOptions

**Change 1 - Simplification**
- Removes
```
        const response = await fetch('{{ route('passkeys.authentication_options') }}')
        const options = await response.json();
```
Adds
```
        const authenticationOptions = await fetch('{{ route('passkeys.authentication_options') }}').then((response) => response.json());
```

**Change 2 - Conforming to Expected**
- Changes 
```
        const startAuthenticationResponse = await startAuthentication(options);
```
To
```
        const startAuthenticationResponse = await startAuthentication({ optionsJSON: authenticationOptions,  });
```
As startAuthentication expects this format