### PR TITLE
Force use of __invoke method

### DIFF
--- a/src/LaravelPasskeysServiceProvider.php
+++ b/src/LaravelPasskeysServiceProvider.php
@@ -34,12 +34,12 @@ class LaravelPasskeysServiceProvider extends PackageServiceProvider
             Route::prefix($prefix)->group(function () {
                 Route::get(
                     'authentication-options',
-                    GeneratePasskeyAuthenticationOptionsController::class
+                    [GeneratePasskeyAuthenticationOptionsController::class, '__invoke']
                 )->name('passkeys.authentication_options');
 
                 Route::post(
                     'authenticate',
-                    AuthenticateUsingPasskeyController::class
+                    [AuthenticateUsingPasskeyController::class, '__invoke']
                 )->name('passkeys.login');
             });
         });


### PR DESCRIPTION
To ensure that __invoke is called when using the route macro