### PR TITLE
Add config tests

### DIFF
--- a/tests/Feature/Support/ConfigTest.php
+++ b/tests/Feature/Support/ConfigTest.php
@@ -1,9 +1,31 @@
 <?php
 
 use Spatie\LaravelPasskeys\Support\Config;
+use Spatie\LaravelPasskeys\Actions\GeneratePasskeyRegisterOptionsAction;
+use Spatie\LaravelPasskeys\Actions\StorePasskeyAction;
+use Spatie\LaravelPasskeys\Actions\GeneratePasskeyAuthenticationOptionsAction;
+use Spatie\LaravelPasskeys\Actions\FindPasskeyToAuthenticateAction;
 
 it('can get the model classes', function () {
     expect(Config::getPassKeyModel())->not()->toBeNull();
 
     expect(Config::getAuthenticatableModel())->not()->toBeNull();
+});
+
+it('can get the default relying party configuration', function () {
+    expect(Config::getRelyingPartyName())->not()->toBeNull();
+
+    expect(Config::getRelyingPartyId())->not()->toBeNull();
+
+    expect(Config::getRelyingPartyIcon())->toBeNull();
+});
+
+it('can get the default action classes', function () {
+    expect(Config::getActionClass('generate_passkey_register_options', GeneratePasskeyRegisterOptionsAction::class))->not->toBeNull()->toBe(GeneratePasskeyRegisterOptionsAction::class);
+
+    expect(Config::getActionClass('store_passkey', StorePasskeyAction::class))->not->toBeNull()->toBe(StorePasskeyAction::class);
+
+    expect(Config::getActionClass('generate_passkey_authentication_options', GeneratePasskeyAuthenticationOptionsAction::class))->not->toBeNull()->toBe(GeneratePasskeyAuthenticationOptionsAction::class);
+
+    expect(Config::getActionClass('find_passkey', FindPasskeyToAuthenticateAction::class))->not->toBeNull()->toBe(FindPasskeyToAuthenticateAction::class);
 });

--- a/tests/Feature/Support/ConfigTest.php
+++ b/tests/Feature/Support/ConfigTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Spatie\LaravelPasskeys\Support\Config;
+use Spatie\LaravelPasskeys\Actions\FindPasskeyToAuthenticateAction;
+use Spatie\LaravelPasskeys\Actions\GeneratePasskeyAuthenticationOptionsAction;
 use Spatie\LaravelPasskeys\Actions\GeneratePasskeyRegisterOptionsAction;
 use Spatie\LaravelPasskeys\Actions\StorePasskeyAction;
-use Spatie\LaravelPasskeys\Actions\GeneratePasskeyAuthenticationOptionsAction;
-use Spatie\LaravelPasskeys\Actions\FindPasskeyToAuthenticateAction;
+use Spatie\LaravelPasskeys\Support\Config;
 
 it('can get the model classes', function () {
     expect(Config::getPassKeyModel())->not()->toBeNull();


### PR DESCRIPTION
This adds some basic tests to ensure that the Config support behaves correctly and:
- returns not-null values for the relyingParty config
- returns the default action classes for the actions