### PR TITLE
[JS] startAuthentication refactor to expected call structure

### DIFF
--- a/resources/views/components/partials/authenticateScript.blade.php
+++ b/resources/views/components/partials/authenticateScript.blade.php
@@ -4,7 +4,7 @@
 
         const options = await response.json();
 
-        const startAuthenticationResponse = await startAuthentication(options);
+        const startAuthenticationResponse = await startAuthentication({ optionsJSON: options, });
 
         const form = document.getElementById('passkey-login-form');
 

--- a/src/Livewire/PasskeysComponent.php
+++ b/src/Livewire/PasskeysComponent.php
@@ -37,7 +37,7 @@ class PasskeysComponent extends Component
     public function storePasskey(string $passkey): void
     {
         $storePasskeyAction = Config::getAction('store_passkey', StorePasskeyAction::class);
- 
+
         try {
             $storePasskeyAction->execute(
                 $this->currentUser(),

--- a/src/Livewire/PasskeysComponent.php
+++ b/src/Livewire/PasskeysComponent.php
@@ -37,7 +37,7 @@ class PasskeysComponent extends Component
     public function storePasskey(string $passkey): void
     {
         $storePasskeyAction = Config::getAction('store_passkey', StorePasskeyAction::class);
-
+ 
         try {
             $storePasskeyAction->execute(
                 $this->currentUser(),


### PR DESCRIPTION
This addresses the console error:

startAuthentication() was not called correctly. It will try to continue with the provided options, but this call should be refactored to use the expected call structure instead. See https://simplewebauthn.dev/docs/packages/browser#typeerror-cannot-read-properties-of-undefined-reading-challenge for more information.