### PR TITLE
[DOCS] - Installation Setup Renumbering, add Listening For Exceptions

### DIFF
--- a/docs/advanced-usage/listening-for-exceptions.md
+++ b/docs/advanced-usage/listening-for-exceptions.md
@@ -1,0 +1,23 @@
+---
+title: Listening for exceptions
+weight: 4
+---
+
+There are several exceptions that may be thrown by the package:
+
+## InvalidActionClass
+This is thrown if you configure an Action that does not extend the default action
+
+## InvalidAuthenticatableModel
+This is thrown if your Authenticatable Model does not:
+  - Implement HasPasskeys
+  - Use the InteractsWithPasskeys trait
+
+## InvalidPasskey
+This is thrown if the Passkey model cannot be obtained/stored, due to invalid JSON, invalid AuthenticatorAttestationResponse, invalid Public Key Credentials etc
+
+## InvalidPasskeyModel
+This is thrown if the Passkey model does not extend Spatie\LaravelPasskeys\Models\Passkey::class
+
+## InvalidPasskeyOptions
+This is thrown if an invalid response is returned when trying to obtain the Authentication Options

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -32,7 +32,7 @@ class User extends Authenticatable implements HasPasskeys
 }
 ```
 
-### Step 4: Optionally set the `AUTH_MODEL` in your `.env` file
+### Step 3: Optionally set the `AUTH_MODEL` in your `.env` file
 
 You'll only need to do this if you're not using the default `User` model. If you're using a different model to authenticate, you must set the `AUTH_MODEL` in your `.env` file to the class name of the model that should be authenticated using passkeys.
 
@@ -92,9 +92,24 @@ The package offers a couple of routes to help generating and authentication pass
 Route::passkeys();
 ```
 
+This macro returns the following:
+```php
+Route::prefix('passkeys')->group(function () {
+    Route::get(
+        'authentication-options',
+        \Spatie\LaravelPasskeys\Http\Controllers\GeneratePasskeyAuthenticationOptionsController::class
+    )->name('passkeys.authentication_options');
+
+    Route::post(
+        'authenticate',
+        \Spatie\LaravelPasskeys\Http\Controllers\AuthenticateUsingPasskeyController::class
+    )->name('passkeys.login');
+});
+```
+
 ### Step 9: Optionally publish the config file
 
-Publishing the config file isn't required. You only need to do this to customize the package's behavior.
+Publishing the config file isn't required. You only need to do this to customize the package's behavior, for example, should you wish to override the default actions.
 
 ```bash
 php artisan vendor:publish --tag="passkeys-config"
@@ -147,19 +162,19 @@ return [
 
 With this setup out of the way, you can now using the components provided by the package to [generate passkeys](https://spatie.be/docs/laravel-passkeys/v1/basic-usage/generating-passkeys) and [authenticate using passkeys](https://spatie.be/docs/laravel-passkeys/v1/basic-usage/authenticating-using-passkeys).
 
-### 8. Add the authentication component to the login view
+### 10. Add the authentication component to the login view
 
 ```html
 <x-authenticate-passkey />
 ```
 
-### 9. Add the passkey management component to the profile view
+### 11. Add the passkey management component to the profile view
 
 ```html
 <livewire:passkeys />
 ```
 
-### 10. (Optional) Publish the views for custom styling
+### 12. (Optional) Publish the views for custom styling
 
 ```bash
 php artisan vendor:publish --tag="passkeys-views"


### PR DESCRIPTION
This is an update only on the docs files.

- Renumbers the docs/installation-setup.md so that it is in a logical order (currently it resets halfway thru)

And
- Creates a new docs/advanced-usage/listening-for-exceptions.md which lists the possible exceptions being thrown (for reference)