### PR TITLE
Add Portuguese translations for passkey-related messages

### DIFF
--- a/resources/lang/pt_BR/passkeys.php
+++ b/resources/lang/pt_BR/passkeys.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'authenticate_using_passkey' => 'Autenticar com chave de acesso',
+    'create' => 'Criar',
+    'delete' => 'Excluir',
+    'error_something_went_wrong_generating_the_passkey' => 'Algo deu errado ao gerar a chave de acesso.',
+    'invalid' => 'Não foi possível fazer login com a chave de acesso fornecida',
+    'last_used' => 'Último uso',
+    'name' => 'Nome',
+    'name_placeholder' => 'Digite o nome da chave de acesso',
+    'no_passkeys_registered' => 'Nenhuma chave de acesso registrada',
+    'not_used_yet' => 'Ainda não utilizada',
+    'passkeys' => 'Chaves de acesso',
+];

--- a/resources/lang/pt_PT/passkeys.php
+++ b/resources/lang/pt_PT/passkeys.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'authenticate_using_passkey' => 'Autenticar com chave de acesso',
+    'create' => 'Criar',
+    'delete' => 'Eliminar',
+    'error_something_went_wrong_generating_the_passkey' => 'Ocorreu um erro ao gerar a chave de acesso.',
+    'invalid' => 'Não foi possível iniciar sessão com a chave de acesso fornecida',
+    'last_used' => 'Última utilização',
+    'name' => 'Nome',
+    'name_placeholder' => 'Introduza o nome da chave de acesso',
+    'no_passkeys_registered' => 'Nenhuma chave de acesso registada',
+    'not_used_yet' => 'Ainda não utilizada',
+    'passkeys' => 'Chaves de acesso',
+];


### PR DESCRIPTION
This PR brings translations for all passkey-related interface messages in both Portuguese (Portugal) and Portuguese (Brazil).