### PR TITLE
Add French and Dutch translations for passkeys

### DIFF
--- a/resources/lang/fr/passkeys.php
+++ b/resources/lang/fr/passkeys.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'authenticate_using_passkey' => 'S\'authentifier avec la passkey',
+    'create' => 'Créer',
+    'delete' => 'Supprimer',
+    'error_something_went_wrong_generating_the_passkey' => 'Une erreur s\'est produite lors de la génération de la passkey.',
+    'invalid' => 'Impossible de se connecter avec la passkey fournie',
+    'last_used' => 'Dernière utilisation',
+    'name' => 'Nom',
+    'name_placeholder' => 'Entrez le nom de la passkey',
+    'no_passkeys_registered' => 'Aucune passkey enregistrée',
+    'not_used_yet' => 'Pas encore utilisée',
+    'passkeys' => 'Passkeys',
+];

--- a/resources/lang/nl/passkeys.php
+++ b/resources/lang/nl/passkeys.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'authenticate_using_passkey' => 'Authenticeren met passkey',
+    'create' => 'Aanmaken',
+    'delete' => 'Verwijderen',
+    'error_something_went_wrong_generating_the_passkey' => 'Er is iets misgegaan bij het genereren van de passkey.',
+    'invalid' => 'Kon niet inloggen met de opgegeven passkey',
+    'last_used' => 'Laatst gebruikt',
+    'name' => 'Naam',
+    'name_placeholder' => 'Voer passkey naam in',
+    'no_passkeys_registered' => 'Geen passkeys geregistreerd',
+    'not_used_yet' => 'Nog niet gebruikt',
+    'passkeys' => 'Passkeys',
+];


### PR DESCRIPTION
This pull request adds translations for the passkeys feature in both French and Dutch languages to improve accessibility for users in French and Dutch-speaking regions.

Thank you guys for this package. We love to start using it for our projects.