### PR TITLE
Redirect to intended URL

### DIFF
--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -92,6 +92,8 @@ class Config
 
     public static function getRedirectAfterLogin(): ?string
     {
-        return config('passkeys.redirect_to_after_login');
+        return redirect()
+            ->intended(config('passkeys.redirect_to_after_login'))
+            ->getTargetUrl();
     }
 }


### PR DESCRIPTION
Updated redirect after login to go to the user's intended URL (where they were before they were sent to the login screen).