### PR TITLE
Add Arabic translations for passkeys

### DIFF
--- a/resources/lang/ar/passkeys.php
+++ b/resources/lang/ar/passkeys.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'authenticate_using_passkey' => 'المصادقة باستخدام مفتاح المرور',
+    'create' => 'إنشاء',
+    'delete' => 'حذف',
+    'error_something_went_wrong_generating_the_passkey' => 'حدث خطأ أثناء إنشاء مفتاح المرور.',
+    'invalid' => 'تعذر تسجيل الدخول باستخدام مفتاح المرور المُقدم',
+    'last_used' => 'آخر استخدام',
+    'name' => 'الاسم',
+    'name_placeholder' => 'أدخل اسم مفتاح المرور',
+    'no_passkeys_registered' => 'لا توجد مفاتيح مرور مسجلة',
+    'not_used_yet' => 'لم يُستخدم بعد',
+    'passkeys' => 'مفاتيح المرور',
+];


### PR DESCRIPTION
This pull request introduces a new Arabic language translation file for passkey-related functionality. The file provides translations for various terms and messages related to passkeys.

Localization additions:

* [`resources/lang/ar/passkeys.php`](diffhunk://#diff-3bcc46ce6a595efaeda21749f8b042dafc7f7bd60172207d717d76808f8a1ad6R1-R15): Added Arabic translations for passkey-related terms, including 'authenticate_using_passkey', 'create', 'delete', 'error_something_went_wrong_generating_the_passkey', and others.