### PR TITLE
Introduce Multi-Auth Support

### DIFF
--- a/config/passkeys.php
+++ b/config/passkeys.php
@@ -4,6 +4,8 @@ return [
     /*
      * After a successful authentication attempt using a passkey
      * we'll redirect to this URL.
+     *
+     * @deprecated Use the `guards` configuration instead.
      */
     'redirect_to_after_login' => '/dashboard',
 
@@ -30,11 +32,33 @@ return [
 
     /*
      * The models used by the package.
-     *
-     * You can override this by specifying your own models
+     * We recommend using the `passkey_model` and `guards` keys instead.
      */
     'models' => [
+        /*
+         * @deprecated Use the `passkey_model` configuration instead.
+         */
         'passkey' => Spatie\LaravelPasskeys\Models\Passkey::class,
+        /*
+         * @deprecated Use the `guards` configuration instead.
+         */
         'authenticatable' => env('AUTH_MODEL', App\Models\User::class),
+    ],
+
+    /*
+     * The model used for passkeys.
+     * This is the recommended way to specify the passkey model.
+     */
+    'passkey_model' => Spatie\LaravelPasskeys\Models\Passkey::class,
+
+    /*
+     * Here you can define the configuration for each of your guards
+     * to support multiple authenticatable models.
+     */
+    'guards' => [
+        // 'web' => [
+        //     'authenticatable' => App\Models\User::class,
+        //     'redirect_to_after_login' => '/dashboard',
+        // ],
     ],
 ];

--- a/database/migrations/update_passkeys_for_multi_auth.php.stub
+++ b/database/migrations/update_passkeys_for_multi_auth.php.stub
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\LaravelPasskeys\Support\Config;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            DB::statement('PRAGMA foreign_keys=off;');
+
+            Schema::rename('passkeys', 'passkeys_old');
+
+            Schema::create('passkeys', function (Blueprint $table) {
+                $table->id();
+                $table->string('authenticatable_id');
+                $table->text('name');
+                $table->text('credential_id');
+                $table->json('data');
+                $table->timestamp('last_used_at')->nullable();
+                $table->timestamps();
+            });
+
+            DB::insert('INSERT INTO passkeys SELECT * FROM passkeys_old');
+
+            Schema::table('passkeys', function (Blueprint $table) {
+                $table->string('authenticatable_type')->nullable()->after('id');
+            });
+
+            if (! Config::isMultiAuthEnabled()) {
+                $model = Config::getAuthenticatableModel();
+                DB::table('passkeys')->update(['authenticatable_type' => $model]);
+            }
+
+            Schema::table('passkeys', function (Blueprint $table) {
+                $table->string('authenticatable_type')->nullable(false)->change();
+                $table->index(['authenticatable_id', 'authenticatable_type'], 'passkeys_authenticatable_index');
+            });
+
+            Schema::drop('passkeys_old');
+
+            DB::statement('PRAGMA foreign_keys=on;');
+        } else {
+            Schema::table('passkeys', function (Blueprint $table) {
+                $table->string('authenticatable_type')->nullable()->after('id');
+            });
+
+            if (! Config::isMultiAuthEnabled()) {
+                $model = Config::getAuthenticatableModel();
+                DB::table('passkeys')->update(['authenticatable_type' => $model]);
+            }
+
+            Schema::table('passkeys', function (Blueprint $table) {
+                $table->string('authenticatable_type')->nullable(false)->change();
+                $table->string('authenticatable_id')->change();
+                $table->index(['authenticatable_id', 'authenticatable_type'], 'passkeys_authenticatable_index');
+                $table->dropForeign('authenticatable_id');
+            });
+        }
+    }
+};

--- a/src/Actions/FindPasskeyToAuthenticateAction.php
+++ b/src/Actions/FindPasskeyToAuthenticateAction.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelPasskeys\Actions;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Spatie\LaravelPasskeys\Models\Passkey;
 use Spatie\LaravelPasskeys\Support\Config;
 use Spatie\LaravelPasskeys\Support\Serializer;
@@ -49,6 +50,18 @@ class FindPasskeyToAuthenticateAction
 
         $this->updatePasskey($passkey, $publicKeyCredentialSource);
 
+        if (Config::isMultiAuthEnabled()) {
+            $guard = $this->resolveGuard($passkey->authenticatable);
+
+            if (is_null($guard)) {
+                return null;
+            }
+
+            // We'll set the guard on the passkey model so we can use it later
+            // in the pipeline, without having to resolve it again.
+            $passkey->setAttribute('guard', $guard);
+        }
+
         return $passkey;
     }
 
@@ -69,7 +82,7 @@ class FindPasskeyToAuthenticateAction
 
     protected function findPasskey(PublicKeyCredential $publicKeyCredential): ?Passkey
     {
-        $passkeyModel = Config::getPassKeyModel();
+        $passkeyModel = Config::getPasskeyModel();
 
         return $passkeyModel::firstWhere('credential_id', mb_convert_encoding($publicKeyCredential->rawId, 'UTF-8'));
     }
@@ -109,5 +122,20 @@ class FindPasskeyToAuthenticateAction
         ]);
 
         return $this;
+    }
+
+    protected function resolveGuard(Authenticatable $authenticatable): ?string
+    {
+        $authenticatableClass = $authenticatable::class;
+
+        foreach (config('auth.guards') as $guard => $config) {
+            $provider = config("auth.providers.{$config['provider']}");
+
+            if (($provider['model'] ?? null) === $authenticatableClass) {
+                return $guard;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Exceptions/GuardNotConfigured.php
+++ b/src/Exceptions/GuardNotConfigured.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelPasskeys\Exceptions;
+
+use Exception;
+
+class GuardNotConfigured extends Exception
+{
+    public static function make(string $guard): self
+    {
+        return new self("The guard `{$guard}` is not configured in the `passkeys.php` config file.");
+    }
+}

--- a/src/Http/Controllers/AuthenticateUsingPasskeyController.php
+++ b/src/Http/Controllers/AuthenticateUsingPasskeyController.php
@@ -37,27 +37,29 @@ class AuthenticateUsingPasskeyController
             return $this->invalidPasskeyResponse();
         }
 
-        $this->logInAuthenticatable($authenticatable);
+        $guard = $passkey->guard ?? null;
+
+        $this->logInAuthenticatable($authenticatable, $guard);
 
         $this->firePasskeyEvent($passkey, $request);
 
-        return $this->validPasskeyResponse($request);
+        return $this->validPasskeyResponse($request, $guard);
     }
 
-    protected function logInAuthenticatable(Authenticatable $authenticatable): self
+    protected function logInAuthenticatable(Authenticatable $authenticatable, ?string $guard = null): self
     {
-        auth()->login($authenticatable);
+        auth()->guard($guard)->login($authenticatable);
 
         Session::regenerate();
 
         return $this;
     }
 
-    protected function validPasskeyResponse(Request $request): RedirectResponse
+    protected function validPasskeyResponse(Request $request, ?string $guard = null): RedirectResponse
     {
         $url = Session::has('passkeys.redirect')
             ? Session::pull('passkeys.redirect')
-            : Config::getRedirectAfterLogin();
+            : Config::getRedirectAfterLogin($guard);
 
         return redirect($url);
     }

--- a/src/Livewire/PasskeysComponent.php
+++ b/src/Livewire/PasskeysComponent.php
@@ -18,6 +18,17 @@ class PasskeysComponent extends Component
     #[Validate('required|string|max:255')]
     public string $name = '';
 
+    public ?string $guard = null;
+
+    public function mount(?string $guard = null): void
+    {
+        if ($guard === null && Config::isMultiAuthEnabled()) {
+            $guard = auth()->getDefaultDriver();
+        }
+
+        $this->guard = $guard;
+    }
+
     public function render(): View
     {
         return view('passkeys::livewire.passkeys', data: [
@@ -62,7 +73,7 @@ class PasskeysComponent extends Component
     public function currentUser(): Authenticatable&HasPasskeys
     {
         /** @var Authenticatable&HasPasskeys $user */
-        $user = auth()->user();
+        $user = auth($this->guard)->user();
 
         return $user;
     }

--- a/src/Models/Concerns/HasPasskeys.php
+++ b/src/Models/Concerns/HasPasskeys.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelPasskeys\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Model
@@ -11,7 +12,10 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 interface HasPasskeys
 {
-    public function passkeys(): HasMany;
+    /**
+     * @return HasMany|MorphMany
+     */
+    public function passkeys();
 
     public function getPassKeyName(): string;
 

--- a/src/Models/Concerns/InteractsWithPasskeys.php
+++ b/src/Models/Concerns/InteractsWithPasskeys.php
@@ -3,15 +3,23 @@
 namespace Spatie\LaravelPasskeys\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Spatie\LaravelPasskeys\Support\Config;
 
 trait InteractsWithPasskeys
 {
-    public function passkeys(): HasMany
+    /**
+     * @return HasMany|MorphMany
+     */
+    public function passkeys()
     {
-        $passkeyModel = Config::getPassKeyModel();
+        $passkeyModel = Config::getPasskeyModel();
 
-        return $this->hasMany($passkeyModel, 'authenticatable_id');
+        if (! Config::isMultiAuthEnabled()) {
+            return $this->hasMany($passkeyModel, 'authenticatable_id');
+        }
+
+        return $this->morphMany($passkeyModel, 'authenticatable');
     }
 
     public function getPasskeyName(): string

--- a/src/Models/Passkey.php
+++ b/src/Models/Passkey.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Spatie\LaravelPasskeys\Database\Factories\PasskeyFactory;
 use Spatie\LaravelPasskeys\Support\Config;
 use Spatie\LaravelPasskeys\Support\Serializer;
@@ -44,11 +45,18 @@ class Passkey extends Model
         );
     }
 
-    public function authenticatable(): BelongsTo
+    /**
+     * @return BelongsTo|MorphTo
+     */
+    public function authenticatable()
     {
-        $authenticatableModel = Config::getAuthenticatableModel();
+        if (! Config::isMultiAuthEnabled()) {
+            $authenticatableModel = Config::getAuthenticatableModel();
 
-        return $this->belongsTo($authenticatableModel);
+            return $this->belongsTo($authenticatableModel);
+        }
+
+        return $this->morphTo();
     }
 
     protected static function newFactory(): Factory

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelPasskeys\Support;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use Spatie\LaravelPasskeys\Exceptions\GuardNotConfigured;
 use Spatie\LaravelPasskeys\Exceptions\InvalidActionClass;
 use Spatie\LaravelPasskeys\Exceptions\InvalidAuthenticatableModel;
 use Spatie\LaravelPasskeys\Exceptions\InvalidPasskeyModel;
@@ -12,24 +13,31 @@ use Spatie\LaravelPasskeys\Models\Passkey;
 class Config
 {
     /**
-     * @return class-string<\Spatie\LaravelPasskeys\Models\Passkey>
+     * @return class-string<Passkey>
      */
-    public static function getPassKeyModel(): string
+    public static function getPasskeyModel(): string
     {
-        $passkeyModel = config('passkeys.models.passkey');
+        $passkeyModel = config('passkeys.passkey_model') ?? config('passkeys.models.passkey');
 
         if (! is_a($passkeyModel, Passkey::class, true)) {
             throw InvalidPasskeyModel::make($passkeyModel);
         }
 
-        return config('passkeys.models.passkey');
+        return $passkeyModel;
     }
 
     /** @return class-string<Authenticatable> */
-    public static function getAuthenticatableModel(): string
+    public static function getAuthenticatableModel(?string $guard = null): string
     {
-        /** @var class-string<Authenticatable> $authenticatableModel */
-        $authenticatableModel = config('passkeys.models.authenticatable');
+        if (! self::isMultiAuthEnabled()) {
+            /** @var class-string<Authenticatable> $authenticatableModel */
+            $authenticatableModel = config('passkeys.models.authenticatable');
+        } else {
+            $guard ??= self::getDefaultGuard();
+
+            /** @var class-string<Authenticatable> $authenticatableModel */
+            $authenticatableModel = self::getGuardConfig($guard, 'authenticatable');
+        }
 
         foreach ([Authenticatable::class, HasPasskeys::class] as $interface) {
             if (! is_a($authenticatableModel, $interface, true)) {
@@ -38,6 +46,19 @@ class Config
         }
 
         return $authenticatableModel;
+    }
+
+    public static function getRedirectAfterLogin(?string $guard = null): string
+    {
+        if (! self::isMultiAuthEnabled()) {
+            return redirect()->intended(config('passkeys.redirect_to_after_login'))->getTargetUrl();
+        }
+
+        $guard ??= self::getDefaultGuard();
+
+        $redirectTo = self::getGuardConfig($guard, 'redirect_to_after_login');
+
+        return redirect()->intended($redirectTo)->getTargetUrl();
     }
 
     public static function getRelyingPartyName(): string
@@ -67,7 +88,7 @@ class Config
 
         self::ensureValidActionClass($actionName, $actionBaseClass, $actionClass);
 
-        return config("passkeys.actions.{$actionName}");
+        return $actionClass;
     }
 
     /**
@@ -90,10 +111,27 @@ class Config
         }
     }
 
-    public static function getRedirectAfterLogin(): ?string
+    public static function isMultiAuthEnabled(): bool
     {
-        return redirect()
-            ->intended(config('passkeys.redirect_to_after_login'))
-            ->getTargetUrl();
+        return ! empty(config('passkeys.guards'));
+    }
+
+    protected static function getDefaultGuard(): string
+    {
+        return config('auth.defaults.guard');
+    }
+
+    /**
+     * @return mixed
+     */
+    protected static function getGuardConfig(string $guard, string $key)
+    {
+        $value = config("passkeys.guards.{$guard}.{$key}");
+
+        if (is_null($value)) {
+            throw GuardNotConfigured::make($guard);
+        }
+
+        return $value;
     }
 }

--- a/tests/Feature/MultiAuth.php
+++ b/tests/Feature/MultiAuth.php
@@ -1,0 +1,34 @@
+<?php
+
+use Livewire\Livewire;
+use Spatie\LaravelPasskeys\Http\Controllers\AuthenticateUsingPasskeyController;
+use Spatie\LaravelPasskeys\Livewire\PasskeysComponent;
+use Spatie\LaravelPasskeys\Models\Passkey;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\Admin;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\User;
+
+// We set up the multi-auth configuration before each test in this file.
+beforeEach(function () {
+    $this->loadMigrationsFrom(__DIR__ . '/../TestSupport/database/migrations');
+
+    // Set up the multi-auth configuration for the tests
+    config(['auth.providers.admins' => [
+        'driver' => 'eloquent',
+        'model' => Admin::class,
+    ]]);
+    config(['auth.guards.admin' => [
+        'driver' => 'session',
+        'provider' => 'admins',
+    ]]);
+    config(['passkeys.guards' => [
+        'web' => [
+            'authenticatable' => User::class,
+            'redirect_to_after_login' => '/dashboard',
+        ],
+        'admin' => [
+            'authenticatable' => Admin::class,
+            'redirect_to_after_login' => '/admin/dashboard',
+        ],
+    ]]);
+});
+

--- a/tests/Feature/MultiAuth/Livewire/PasskeyComponentTest.php
+++ b/tests/Feature/MultiAuth/Livewire/PasskeyComponentTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Livewire\Livewire;
+use Spatie\LaravelPasskeys\Http\Controllers\AuthenticateUsingPasskeyController;
+use Spatie\LaravelPasskeys\Livewire\PasskeysComponent;
+use Spatie\LaravelPasskeys\Models\Passkey;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\Admin;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\User;
+
+it('can mount the PasskeysComponent', function () {
+    $user = User::factory()->create();
+
+    auth()->login($user);
+
+    Livewire::test(PasskeysComponent::class)
+        ->assertStatus(200);
+});
+
+it ('can mount the PasskeyComponent with not default guard', function () {
+     $user = Admin::factory()->create();
+
+     auth('admin')->login($user);
+
+     Livewire::test(PasskeysComponent::class, ['guard' => 'admin'])
+         ->assertStatus(200);
+});

--- a/tests/Feature/MultiAuth/MigrationUpgradeTest.php
+++ b/tests/Feature/MultiAuth/MigrationUpgradeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Spatie\LaravelPasskeys\Models\Passkey;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\User;
+
+it ('can upgrade passkeys table while keeping existing records healthy', function () {
+    $passkey = Passkey::factory()->create();
+
+    $this->assertDatabaseCount('passkeys', 1);
+    $this->assertDatabaseCount('users', 1);
+
+    $foreignKeysBefore = Schema::getForeignKeys('passkeys');
+
+    expect($foreignKeysBefore)
+        ->toBeArray()
+        ->and(collect($foreignKeysBefore)->contains('columns', ['authenticatable_id']))
+        ->toBeTrue('The original foreign key should exist before the migration.');
+
+    $migration = include __DIR__.'/../../../database/migrations/update_passkeys_for_multi_auth.php.stub';
+    $migration->up();
+
+    $this->assertDatabaseHas('passkeys', [
+        'authenticatable_type' => User::class,
+        'authenticatable_id' => $passkey->authenticatable_id,
+    ]);
+
+    $foreignKeysAfter = Schema::getForeignKeys('passkeys');
+
+    expect(collect($foreignKeysAfter)->contains('columns', ['authenticatable_id']))
+        ->toBeFalse('The old foreign key should have been removed.')
+        ->and(Schema::hasIndex('passkeys', 'passkeys_authenticatable_index'))
+        ->toBeTrue('A new index on the polymorphic columns should exist.');
+});

--- a/tests/Feature/MultiAuth/Support/ConfigTest.php
+++ b/tests/Feature/MultiAuth/Support/ConfigTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Spatie\LaravelPasskeys\Support\Config;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\Admin;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\User;
+
+it ('can get model classes', function () {
+    expect(Config::getAuthenticatableModel('web'))->not()->toBeNull();
+
+    expect(Config::getAuthenticatableModel('admin'))->not()->toBeNull();
+});
+
+it ('can get correct model classes for specific auth guard', function () {
+    expect(Config::getAuthenticatableModel('web'))->toBe(User::class);
+
+    expect(Config::getAuthenticatableModel('admin'))->toBe(Admin::class);
+});
+
+it ('can get correct model with default guard', function () {
+    expect(Config::getAuthenticatableModel())->toBe(User::class);
+});

--- a/tests/MultiAuthTestCase.php
+++ b/tests/MultiAuthTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\LaravelPasskeys\Tests;
+
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\Admin;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\User;
+
+class MultiAuthTestCase extends TestCase
+{
+    public function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // Set deprecated configuration to null
+        config()->set('passkeys.models.authenticatable');
+        config()->set('passkeys.redirect_to_after_login');
+        config()->set('passkeys.models.passkey');
+
+        // Set configuration for multi auth passkeys
+        config()->set('auth.providers.admins.driver', 'eloquent');
+        config()->set('auth.providers.admins.model', Admin::class);
+        config()->set('auth.guards.admin.driver', 'session');
+        config()->set('auth.guards.admin.provider', 'admins');
+        config()->set('passkeys.guards.web.authenticatable', User::class);
+        config()->set('passkeys.guards.web.redirect_to_after_login', '/dashboard');
+        config()->set('passkeys.guards.admin.authenticatable', Admin::class);
+        config()->set('passkeys.guards.admin.redirect_to_after_login', '/admin/dashboard');
+
+        $migration = include __DIR__.'/TestSupport/database/migrations/create_admins_table.php';
+        $migration->up();
+
+        $migration = include __DIR__.'/../database/migrations/update_passkeys_for_multi_auth.php.stub';
+        $migration->up();
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,16 @@
 <?php
 
+use Spatie\LaravelPasskeys\Tests\MultiAuthTestCase;
 use Spatie\LaravelPasskeys\Tests\TestCase;
 
-uses(TestCase::class)->in(__DIR__);
+uses(TestCase::class)->in(
+    __DIR__ . '/Feature/Actions',
+    __DIR__ . '/Feature/Livewire',
+    __DIR__ . '/Feature/Support',
+    __DIR__ . '/Feature/MultiAuth/MigrationUpgradeTest.php'
+);
+
+uses(MultiAuthTestCase::class)->in(
+    __DIR__.'/Feature/MultiAuth/Livewire',
+    __DIR__.'/Feature/MultiAuth/Support'
+);

--- a/tests/TestSupport/Factories/AdminFactory.php
+++ b/tests/TestSupport/Factories/AdminFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\LaravelPasskeys\Tests\TestSupport\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Models\Admin;
+
+class AdminFactory extends Factory
+{
+    protected $model = Admin::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => Hash::make('password'),
+            'remember_token' => Str::random(10),
+        ];
+    }
+}

--- a/tests/TestSupport/Models/Admin.php
+++ b/tests/TestSupport/Models/Admin.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\LaravelPasskeys\Tests\TestSupport\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
+use Spatie\LaravelPasskeys\Models\Concerns\InteractsWithPasskeys;
+use Spatie\LaravelPasskeys\Tests\TestSupport\Factories\AdminFactory;
+
+class Admin extends \Illuminate\Foundation\Auth\User implements HasPasskeys
+{
+    use HasFactory;
+    use InteractsWithPasskeys;
+
+    protected static function newFactory(): Factory
+    {
+        return AdminFactory::new();
+    }
+}

--- a/tests/TestSupport/database/migrations/create_admins_table.php
+++ b/tests/TestSupport/database/migrations/create_admins_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('admins', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+};


### PR DESCRIPTION
This introduces the possibility to define multiple auth guards to handle passkeys while keeping compatibility with lower versions. 

To avoid breaking changes, all methods and the updated passkeys table are still compatible with the single authenticatable model design before. 

Nonetheless the changes are breaking the single model concept and needs an to be explained. So maybe better for a major version 2 of this package.

### How does it works?

The passkey component will now boot with a guard attribute (If empty it will use the default configured guard). Possible guards can be configured inside the package config file. For login with a passkey the guard attribute will be used to resolve the user model and select the correct passkey by authenticatable_type column. 

**Configuration**
```php
return [

    // ...

    /*
     * The model used for passkeys.
     * This is the recommended way to specify the passkey model.
     */
    'passkey_model' => Spatie\LaravelPasskeys\Models\Passkey::class,

    /*
     * Here you can define the configuration for each of your guards
     * to support multiple authenticatable models.
     */
    'guards' => [
        'web' => [
            'authenticatable' => App\Models\User::class,
            'redirect_to_after_login' => '/dashboard',
        ],
    ],
];
```

