### PR TITLE
Add remember parameter to authenticateWithPasskey

### DIFF
--- a/resources/views/components/partials/authenticateScript.blade.php
+++ b/resources/views/components/partials/authenticateScript.blade.php
@@ -1,5 +1,5 @@
 <script>
-    async function authenticateWithPasskey() {
+    async function authenticateWithPasskey(remember = false) {
         const response = await fetch('{{ route('passkeys.authentication_options') }}')
 
         const options = await response.json();
@@ -7,8 +7,9 @@
         const startAuthenticationResponse = await startAuthentication({ optionsJSON: options, });
 
         const form = document.getElementById('passkey-login-form');
-
+    
         form.addEventListener('formdata', ({formData}) => {
+            formData.set('remember', remember);
             formData.set('start_authentication_response', JSON.stringify(startAuthenticationResponse));
         });
 


### PR DESCRIPTION
Exposes the remember functionality of AuthenticateUsingPasskeyController so it becomes usable from Livewire or JavaScript. 

I checked whether this feature might already exist and came across #72. 
After reviewing the code I noticed that the controller already reads a remember boolean from the request, but the flag was not exposed to the client. 

The solution in this PR simply makes that parameter available. It keeps full backward compatibility and allows usage such as wire:click="authenticateWithPasskey($remember)", making the remember behavior easy to customize in the component. 

If a different technical approach is preferred, I am happy to update the implementation accordingly.