### PR TITLE
Update Dutch translations for passkeys terminology

### DIFF
--- a/resources/lang/nl/passkeys.php
+++ b/resources/lang/nl/passkeys.php
@@ -1,15 +1,15 @@
 <?php
 
 return [
-    'authenticate_using_passkey' => 'Authenticeren met passkey',
+    'authenticate_using_passkey' => 'Authenticeren met toegangssleutel',
     'create' => 'Aanmaken',
     'delete' => 'Verwijderen',
-    'error_something_went_wrong_generating_the_passkey' => 'Er is iets misgegaan bij het genereren van de passkey.',
-    'invalid' => 'Kon niet inloggen met de opgegeven passkey',
+    'error_something_went_wrong_generating_the_passkey' => 'Er is iets misgegaan bij het genereren van de toegangssleutel.',
+    'invalid' => 'Inloggen met de toegangssleutel is niet gelukt.',
     'last_used' => 'Laatst gebruikt',
     'name' => 'Naam',
-    'name_placeholder' => 'Voer passkey naam in',
-    'no_passkeys_registered' => 'Geen passkeys geregistreerd',
+    'name_placeholder' => 'Voer een naam voor de toegangssleutel in.',
+    'no_passkeys_registered' => 'Geen toegangssleutels geregistreerd.',
     'not_used_yet' => 'Nog niet gebruikt',
-    'passkeys' => 'Passkeys',
+    'passkeys' => 'Toegangssleutels',
 ];


### PR DESCRIPTION
In Dutch, "toegangssleutel" is the correct term for Passkeys now. This is the term used by Google, 1Password, etc.