### PR TITLE
Fix PublicKeyCredentialSource type-hint issues with webauthn-lib 5.3+

### DIFF
--- a/config/passkeys.php
+++ b/config/passkeys.php
@@ -1,5 +1,13 @@
 <?php
 
+use App\Models\User;
+use Spatie\LaravelPasskeys\Actions\ConfigureCeremonyStepManagerFactoryAction;
+use Spatie\LaravelPasskeys\Actions\FindPasskeyToAuthenticateAction;
+use Spatie\LaravelPasskeys\Actions\GeneratePasskeyAuthenticationOptionsAction;
+use Spatie\LaravelPasskeys\Actions\GeneratePasskeyRegisterOptionsAction;
+use Spatie\LaravelPasskeys\Actions\StorePasskeyAction;
+use Spatie\LaravelPasskeys\Models\Passkey;
+
 return [
     /*
      * After a successful authentication attempt using a passkey
@@ -13,11 +21,11 @@ return [
      * by specifying your custom class name here.
      */
     'actions' => [
-        'generate_passkey_register_options' => Spatie\LaravelPasskeys\Actions\GeneratePasskeyRegisterOptionsAction::class,
-        'store_passkey' => Spatie\LaravelPasskeys\Actions\StorePasskeyAction::class,
-        'generate_passkey_authentication_options' => \Spatie\LaravelPasskeys\Actions\GeneratePasskeyAuthenticationOptionsAction::class,
-        'find_passkey' => Spatie\LaravelPasskeys\Actions\FindPasskeyToAuthenticateAction::class,
-        'configure_ceremony_step_manager_factory' => Spatie\LaravelPasskeys\Actions\ConfigureCeremonyStepManagerFactoryAction::class,
+        'generate_passkey_register_options' => GeneratePasskeyRegisterOptionsAction::class,
+        'store_passkey' => StorePasskeyAction::class,
+        'generate_passkey_authentication_options' => GeneratePasskeyAuthenticationOptionsAction::class,
+        'find_passkey' => FindPasskeyToAuthenticateAction::class,
+        'configure_ceremony_step_manager_factory' => ConfigureCeremonyStepManagerFactoryAction::class,
     ],
 
     /*
@@ -35,7 +43,7 @@ return [
      * You can override this by specifying your own models
      */
     'models' => [
-        'passkey' => Spatie\LaravelPasskeys\Models\Passkey::class,
-        'authenticatable' => env('AUTH_MODEL', App\Models\User::class),
+        'passkey' => Passkey::class,
+        'authenticatable' => env('AUTH_MODEL', User::class),
     ],
 ];

--- a/database/factories/PasskeyFactory.php
+++ b/database/factories/PasskeyFactory.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelPasskeys\Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Spatie\LaravelPasskeys\Models\Passkey;
 use Spatie\LaravelPasskeys\Support\Config;
+use Spatie\LaravelPasskeys\Support\CredentialRecordConverter;
 use Symfony\Component\Uid\Uuid;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialSource;
@@ -28,7 +29,7 @@ class PasskeyFactory extends Factory
 
     protected function dummyPublicKeyCredentialSource(): PublicKeyCredentialSource
     {
-        return PublicKeyCredentialSource::create(
+        return CredentialRecordConverter::toPublicKeyCredentialSource(PublicKeyCredentialSource::create(
             base64_decode(
                 'eHouz/Zi7+BmByHjJ/tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp/B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB+w==',
                 true
@@ -36,7 +37,7 @@ class PasskeyFactory extends Factory
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
             'none',
-            $trustPath ?? EmptyTrustPath::create(),
+            EmptyTrustPath::create(),
             Uuid::fromString('00000000-0000-0000-0000-000000000000'),
             base64_decode(
                 'pQECAyYgASFYIJV56vRrFusoDf9hm3iDmllcxxXzzKyO9WruKw4kWx7zIlgg/nq63l8IMJcIdKDJcXRh9hoz0L+nVwP1Oxil3/oNQYs=',
@@ -44,6 +45,6 @@ class PasskeyFactory extends Factory
             ),
             'foo',
             100,
-        );
+        ));
     }
 }

--- a/src/Models/Concerns/HasPasskeys.php
+++ b/src/Models/Concerns/HasPasskeys.php
@@ -2,12 +2,15 @@
 
 namespace Spatie\LaravelPasskeys\Models\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
+use Spatie\LaravelPasskeys\Models\Passkey;
 
 /**
- * @mixin \Illuminate\Database\Eloquent\Model
+ * @mixin Model
  *
- * @property \Illuminate\Support\Collection<\Spatie\LaravelPasskeys\Models\Passkey> $passkeys
+ * @property Collection<Passkey> $passkeys
  */
 interface HasPasskeys
 {

--- a/src/Models/Passkey.php
+++ b/src/Models/Passkey.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\DB;
 use Spatie\LaravelPasskeys\Database\Factories\PasskeyFactory;
 use Spatie\LaravelPasskeys\Support\Config;
+use Spatie\LaravelPasskeys\Support\CredentialRecordConverter;
 use Spatie\LaravelPasskeys\Support\Serializer;
 use Webauthn\PublicKeyCredentialSource;
 
@@ -34,9 +35,11 @@ class Passkey extends Model
         $serializer = Serializer::make();
 
         return new Attribute(
-            get: fn (string $value) => $serializer->fromJson(
-                $value,
-                PublicKeyCredentialSource::class,
+            get: fn (string $value): PublicKeyCredentialSource => CredentialRecordConverter::toPublicKeyCredentialSource(
+                $serializer->fromJson(
+                    $value,
+                    PublicKeyCredentialSource::class,
+                )
             ),
             set: fn (PublicKeyCredentialSource $value) => [
                 'credential_id' => self::encodeCredentialId($value->publicKeyCredentialId),

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -12,7 +12,7 @@ use Spatie\LaravelPasskeys\Models\Passkey;
 class Config
 {
     /**
-     * @return class-string<\Spatie\LaravelPasskeys\Models\Passkey>
+     * @return class-string<Passkey>
      */
     public static function getPassKeyModel(): string
     {

--- a/src/Support/Serializer.php
+++ b/src/Support/Serializer.php
@@ -14,7 +14,7 @@ class Serializer
     {
         $attestationStatementSupportManager = AttestationStatementSupportManager::create();
 
-        /** @var \Symfony\Component\Serializer\Serializer $serializer */
+        /** @var SymfonySerializer $serializer */
         $serializer = (new WebauthnSerializerFactory($attestationStatementSupportManager))->create();
 
         return new self($serializer);

--- a/tests/Feature/Models/PasskeyTest.php
+++ b/tests/Feature/Models/PasskeyTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Spatie\LaravelPasskeys\Models\Passkey;
+use Webauthn\PublicKeyCredentialSource;
+
+it('can access the data attribute as a PublicKeyCredentialSource', function () {
+    $passkey = Passkey::factory()->create();
+
+    $passkey = $passkey->fresh();
+
+    expect($passkey->data)->toBeInstanceOf(PublicKeyCredentialSource::class);
+});


### PR DESCRIPTION
## Summary

- In webauthn-lib 5.3+, `PublicKeyCredentialSource::create()` and the serializer's `fromJson()` can return `CredentialRecord` instead of `PublicKeyCredentialSource`, causing type errors.
- Wraps the Passkey model's `data` accessor getter and the factory's `dummyPublicKeyCredentialSource()` with `CredentialRecordConverter::toPublicKeyCredentialSource()` to ensure the correct type.
- Fixes an undefined `$trustPath` variable in the factory.
- Adds a test that verifies the `data` attribute returns a `PublicKeyCredentialSource` after a round-trip through the database.

Inspired by #106.