### PR TITLE
Fix: Allow string in deletePasskey method

### DIFF
--- a/src/Livewire/PasskeysComponent.php
+++ b/src/Livewire/PasskeysComponent.php
@@ -57,7 +57,7 @@ class PasskeysComponent extends Component
         $this->clearForm();
     }
 
-    public function deletePasskey(int $passkeyId): void
+    public function deletePasskey(int|string $passkeyId): void
     {
         $this->currentUser()->passkeys()->where('id', $passkeyId)->delete();
     }


### PR DESCRIPTION
Allow string in `deletePasskey()` method to support UUID identifiers.