### PR TITLE
Persist passkey authentication options across intermediate requests

### DIFF
--- a/src/Actions/GeneratePasskeyAuthenticationOptionsAction.php
+++ b/src/Actions/GeneratePasskeyAuthenticationOptionsAction.php
@@ -20,7 +20,7 @@ class GeneratePasskeyAuthenticationOptionsAction
 
         $options = Serializer::make()->toJson($options);
 
-        Session::flash('passkey-authentication-options', $options);
+        Session::put('passkey-authentication-options', $options);
 
         return $options;
     }

--- a/src/Http/Controllers/AuthenticateUsingPasskeyController.php
+++ b/src/Http/Controllers/AuthenticateUsingPasskeyController.php
@@ -16,6 +16,12 @@ class AuthenticateUsingPasskeyController
 {
     public function __invoke(AuthenticateUsingPasskeysRequest $request)
     {
+        $passkeyOptions = Session::pull('passkey-authentication-options');
+
+        if (blank($passkeyOptions)) {
+            return $this->invalidPasskeyResponse();
+        }
+
         $findAuthenticatableUsingPasskey = Config::getAction(
             'find_passkey',
             FindPasskeyToAuthenticateAction::class
@@ -23,7 +29,7 @@ class AuthenticateUsingPasskeyController
 
         $passkey = $findAuthenticatableUsingPasskey->execute(
             $request->input('start_authentication_response'),
-            Session::get('passkey-authentication-options'),
+            $passkeyOptions,
         );
 
         if (! $passkey) {

--- a/tests/Feature/Actions/GeneratePasskeyAuthenticationOptionsActionTest.php
+++ b/tests/Feature/Actions/GeneratePasskeyAuthenticationOptionsActionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\Session;
+use Spatie\LaravelPasskeys\Actions\GeneratePasskeyAuthenticationOptionsAction;
+use Spatie\LaravelPasskeys\Support\Config;
+
+beforeEach(function () {
+    $this->action = Config::getAction(
+        'generate_passkey_authentication_options',
+        GeneratePasskeyAuthenticationOptionsAction::class,
+    );
+});
+
+it('persists options across the flash lifecycle so intermediate requests do not consume them', function () {
+    Session::start();
+
+    $options = $this->action->execute();
+
+    // Simulate the session middleware running for two intermediate
+    // requests between the generate-options call and the authenticate POST
+    // (e.g. a Livewire poll and an asset request). Flash data is gone after
+    // a single intermediate request, so put-based storage is required.
+    Session::ageFlashData();
+    Session::ageFlashData();
+
+    expect(Session::get('passkey-authentication-options'))->toBe($options);
+});


### PR DESCRIPTION
## Bug

`GeneratePasskeyAuthenticationOptionsAction` stores the WebAuthn challenge with `Session::flash`, which only survives one subsequent request. `AuthenticateUsingPasskeyController` then reads it with `Session::get`. In practice, any intermediate request between the generate-options call and the authenticate POST (a Livewire poll, an asset load, a background fetch) ages the flash data out, so the controller passes `null` into `FindPasskeyToAuthenticateAction` and the action throws a `TypeError`:

```
Spatie\LaravelPasskeys\Actions\FindPasskeyToAuthenticateAction::execute():
Argument #2 ($passkeyOptionsJson) must be of type string, null given,
called in .../AuthenticateUsingPasskeyController.php on line 24
```

The user-visible result is that passkey authentication fails intermittently, especially on pages that issue any background HTTP traffic between the moment the WebAuthn challenge is fetched and the moment the user completes the biometric prompt.

## Fix

- `GeneratePasskeyAuthenticationOptionsAction`: `Session::flash` → `Session::put`. The value now persists across any number of intermediate requests.
- `AuthenticateUsingPasskeyController`: `Session::get` → `Session::pull`. The value is atomically read and removed when the authenticate endpoint runs, so the single-use guarantee that the flash flow provided is preserved without depending on Laravel's flash lifecycle.
- Short-circuit the controller with `invalidPasskeyResponse()` when the session value is missing, which also avoids the `TypeError` if the authenticate endpoint is ever called without first calling `generate-authentication-options`.

This matches the `put`/`pull` pattern already used by `Livewire/PasskeysComponent.php` for the registration flow.

## Test

Added `tests/Feature/Actions/GeneratePasskeyAuthenticationOptionsActionTest.php`. It runs `Session::ageFlashData()` twice to simulate session middleware running across two intermediate requests, then asserts the options are still in the session. The test fails on `main` and passes after this change.

`vendor/bin/pest` and `vendor/bin/pint` are clean. `vendor/bin/phpstan analyse` shows no new errors on the changed files.