### PR TITLE
Fix webauthn-lib 5.3 relying party name deprecation

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '**.php'
       - 'phpstan.neon.dist'
+      - 'phpstan-baseline.neon'
       - '.github/workflows/phpstan.yml'
 
 jobs:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.2|^8.3|^8.4",
         "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.16",
-        "web-auth/webauthn-lib": "^5.0|5.3.x-dev as 5.3.0"
+        "web-auth/webauthn-lib": "^5.3"
     },
     "require-dev": {
         "larastan/larastan": "^3.4",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,6 +7,48 @@ parameters:
 			path: src/Actions/FindPasskeyToAuthenticateAction.php
 
 		-
+			message: '''
+				#^Parameter \$publicKeyCredentialSource of method Spatie\\LaravelPasskeys\\Actions\\FindPasskeyToAuthenticateAction\:\:updatePasskey\(\) has typehint with deprecated class Webauthn\\PublicKeyCredentialSource\:
+				since 5\.3, use CredentialRecord instead\. Will be removed in 6\.0\.$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: src/Actions/FindPasskeyToAuthenticateAction.php
+
+		-
+			message: '''
+				#^Return type of method Spatie\\LaravelPasskeys\\Actions\\FindPasskeyToAuthenticateAction\:\:determinePublicKeyCredentialSource\(\) has typehint with deprecated class Webauthn\\PublicKeyCredentialSource\:
+				since 5\.3, use CredentialRecord instead\. Will be removed in 6\.0\.$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: src/Actions/FindPasskeyToAuthenticateAction.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$name of class Webauthn\\PublicKeyCredentialEntity\:
+				since 5\.3\.0 and will be removed in 6\.0\.0\. Please set "" and use PublicKeyCredentialUserEntity\.name instead\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: src/Actions/GeneratePasskeyRegisterOptionsAction.php
+
+		-
+			message: '#^Parameter \#1 \$attributes of method Illuminate\\Database\\Eloquent\\Relations\\HasOneOrMany\<.+\>\:\:create\(\) expects array\<model property of .+, mixed\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Actions/StorePasskeyAction.php
+
+		-
+			message: '''
+				#^Return type of method Spatie\\LaravelPasskeys\\Actions\\StorePasskeyAction\:\:determinePublicKeyCredentialSource\(\) has typehint with deprecated class Webauthn\\PublicKeyCredentialSource\:
+				since 5\.3, use CredentialRecord instead\. Will be removed in 6\.0\.$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: src/Actions/StorePasskeyAction.php
+
+		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
 			count: 1
@@ -25,7 +67,52 @@ parameters:
 			path: src/Models/Concerns/InteractsWithPasskeys.php
 
 		-
+			message: '''
+				#^Access to constant on deprecated class Webauthn\\PublicKeyCredentialSource\:
+				since 5\.3, use CredentialRecord instead\. Will be removed in 6\.0\.$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/Models/Passkey.php
+
+		-
 			message: '#^Parameter \#1 \$related of method Illuminate\\Database\\Eloquent\\Model\:\:belongsTo\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Model\>, class\-string\<Illuminate\\Contracts\\Auth\\Authenticatable\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Models/Passkey.php
+
+		-
+			message: '''
+				#^Parameter \$value of anonymous function has typehint with deprecated class Webauthn\\PublicKeyCredentialSource\:
+				since 5\.3, use CredentialRecord instead\. Will be removed in 6\.0\.$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: src/Models/Passkey.php
+
+		-
+			message: '''
+				#^Return type of anonymous function has typehint with deprecated class Webauthn\\PublicKeyCredentialSource\:
+				since 5\.3, use CredentialRecord instead\. Will be removed in 6\.0\.$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: src/Models/Passkey.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Webauthn\\PublicKeyCredentialSource\:
+				since 5\.3, use CredentialRecord instead\. Will be removed in 6\.0\.$#
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: src/Support/CredentialRecordConverter.php
+
+		-
+			message: '''
+				#^Return type of method Spatie\\LaravelPasskeys\\Support\\CredentialRecordConverter\:\:toPublicKeyCredentialSource\(\) has typehint with deprecated class Webauthn\\PublicKeyCredentialSource\:
+				since 5\.3, use CredentialRecord instead\. Will be removed in 6\.0\.$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: src/Support/CredentialRecordConverter.php

--- a/src/Actions/GeneratePasskeyRegisterOptionsAction.php
+++ b/src/Actions/GeneratePasskeyRegisterOptionsAction.php
@@ -3,11 +3,13 @@
 namespace Spatie\LaravelPasskeys\Actions;
 
 use Illuminate\Support\Str;
+use ReflectionProperty;
 use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
 use Spatie\LaravelPasskeys\Support\Config;
 use Spatie\LaravelPasskeys\Support\Serializer;
 use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialEntity;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
 
@@ -34,11 +36,27 @@ class GeneratePasskeyRegisterOptionsAction
 
     protected function relatedPartyEntity(): PublicKeyCredentialRpEntity
     {
-        return new PublicKeyCredentialRpEntity(
-            name: Config::getRelyingPartyName(),
-            id: Config::getRelyingPartyId(),
-            icon: Config::getRelyingPartyIcon(),
-        );
+        $name = Config::getRelyingPartyName();
+        $id = Config::getRelyingPartyId();
+        $icon = Config::getRelyingPartyIcon();
+
+        // In web-auth/webauthn-lib 5.3+, passing a name to the constructor is
+        // deprecated in favour of assigning the public `name` property. In
+        // older versions that property is readonly, so the name still has to
+        // be passed through the constructor.
+        if ($this->entityNameIsWritable()) {
+            $entity = new PublicKeyCredentialRpEntity(name: '', id: $id, icon: $icon);
+            $entity->name = $name;
+
+            return $entity;
+        }
+
+        return new PublicKeyCredentialRpEntity(name: $name, id: $id, icon: $icon);
+    }
+
+    protected function entityNameIsWritable(): bool
+    {
+        return ! (new ReflectionProperty(PublicKeyCredentialEntity::class, 'name'))->isReadOnly();
     }
 
     public function generateUserEntity(HasPasskeys $authenticatable): PublicKeyCredentialUserEntity

--- a/src/Actions/GeneratePasskeyRegisterOptionsAction.php
+++ b/src/Actions/GeneratePasskeyRegisterOptionsAction.php
@@ -3,13 +3,11 @@
 namespace Spatie\LaravelPasskeys\Actions;
 
 use Illuminate\Support\Str;
-use ReflectionProperty;
 use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
 use Spatie\LaravelPasskeys\Support\Config;
 use Spatie\LaravelPasskeys\Support\Serializer;
 use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\PublicKeyCredentialCreationOptions;
-use Webauthn\PublicKeyCredentialEntity;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
 
@@ -36,27 +34,17 @@ class GeneratePasskeyRegisterOptionsAction
 
     protected function relatedPartyEntity(): PublicKeyCredentialRpEntity
     {
-        $name = Config::getRelyingPartyName();
-        $id = Config::getRelyingPartyId();
-        $icon = Config::getRelyingPartyIcon();
+        $entity = new PublicKeyCredentialRpEntity(
+            name: '',
+            id: Config::getRelyingPartyId(),
+            icon: Config::getRelyingPartyIcon(),
+        );
 
-        // In web-auth/webauthn-lib 5.3+, passing a name to the constructor is
-        // deprecated in favour of assigning the public `name` property. In
-        // older versions that property is readonly, so the name still has to
-        // be passed through the constructor.
-        if ($this->entityNameIsWritable()) {
-            $entity = new PublicKeyCredentialRpEntity(name: '', id: $id, icon: $icon);
-            $entity->name = $name;
+        // web-auth/webauthn-lib 5.3 deprecates passing the name to the
+        // constructor; it has to be assigned through the property instead.
+        $entity->name = Config::getRelyingPartyName();
 
-            return $entity;
-        }
-
-        return new PublicKeyCredentialRpEntity(name: $name, id: $id, icon: $icon);
-    }
-
-    protected function entityNameIsWritable(): bool
-    {
-        return ! (new ReflectionProperty(PublicKeyCredentialEntity::class, 'name'))->isReadOnly();
+        return $entity;
     }
 
     public function generateUserEntity(HasPasskeys $authenticatable): PublicKeyCredentialUserEntity

--- a/tests/Feature/Actions/GeneratePasskeyRegisterOptionsActionTest.php
+++ b/tests/Feature/Actions/GeneratePasskeyRegisterOptionsActionTest.php
@@ -27,3 +27,21 @@ it('can generate options to register a passkey as an object', function () {
 
     expect($output)->toBeInstanceOf(PublicKeyCredentialCreationOptions::class);
 });
+
+it('does not trigger deprecation warnings when generating register options', function () {
+    $deprecations = [];
+
+    set_error_handler(function (int $errno, string $errstr) use (&$deprecations): bool {
+        $deprecations[] = $errstr;
+
+        return true;
+    }, E_USER_DEPRECATED);
+
+    try {
+        $this->action->execute($this->user);
+    } finally {
+        restore_error_handler();
+    }
+
+    expect($deprecations)->toBe([]);
+});


### PR DESCRIPTION
Fixes #119

## Problem

On webauthn-lib 5.3 every passkey registration logs a deprecation warning:

> Since web-auth/webauthn-lib 5.3.0: The parameter "$name" is deprecated since 5.3.0 and will be removed in 6.0.0. Please set "" and use PublicKeyCredentialUserEntity.name instead.

In 5.3 the `$name` constructor parameter of `PublicKeyCredentialEntity` is deprecated; the name has to be assigned via the public `name` property instead. `PublicKeyCredentialUserEntity` already does this internally, but `PublicKeyCredentialRpEntity` still forwards its name to the deprecated parent parameter. Building the relying party entity in `GeneratePasskeyRegisterOptionsAction` therefore triggered the warning on every registration.

## Changes

- `relatedPartyEntity()` now assigns the relying party name through the `name` property when it is writable (webauthn-lib 5.3+) and keeps passing it through the constructor on older versions, where the property is `readonly`. This keeps support for `web-auth/webauthn-lib: ^5.0` intact.
- Added a test that fails if generating register options emits any `E_USER_DEPRECATED`.
- Regenerated the PHPStan baseline to acknowledge the deprecation notices that webauthn-lib 5.3 raises for `PublicKeyCredentialSource` (the package intentionally keeps storing credentials as `PublicKeyCredentialSource`, converting `CredentialRecord` back via `CredentialRecordConverter`) and for the relying party name property.