### PR TITLE
Avoid webauthn-lib 5.3 CredentialRecord deprecations during authentication

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -34,6 +34,15 @@ parameters:
 			path: src/Actions/GeneratePasskeyRegisterOptionsAction.php
 
 		-
+			message: '''
+				#^Access to deprecated property \$name of class Webauthn\\PublicKeyCredentialEntity\:
+				since 5\.3\.0 and will be removed in 6\.0\.0\. Please set "" and use PublicKeyCredentialUserEntity\.name instead\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: src/Support/PublicKeyCredentialRpEntityDenormalizer.php
+
+		-
 			message: '#^Parameter \#1 \$attributes of method Illuminate\\Database\\Eloquent\\Relations\\HasOneOrMany\<.+\>\:\:create\(\) expects array\<model property of .+, mixed\>, array given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Actions/FindPasskeyToAuthenticateAction.php
+++ b/src/Actions/FindPasskeyToAuthenticateAction.php
@@ -92,7 +92,7 @@ class FindPasskeyToAuthenticateAction
             $validator = AuthenticatorAssertionResponseValidator::create($requestCsm);
 
             $publicKeyCredentialSource = $validator->check(
-                $passkey->data,
+                CredentialRecordConverter::toCredentialRecord($passkey->data),
                 $publicKeyCredential->response,
                 $passkeyOptions,
                 $relyingPartyId,

--- a/src/Support/CredentialRecordConverter.php
+++ b/src/Support/CredentialRecordConverter.php
@@ -2,10 +2,42 @@
 
 namespace Spatie\LaravelPasskeys\Support;
 
+use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialSource;
 
 class CredentialRecordConverter
 {
+    /**
+     * Convert the given credential to a plain CredentialRecord instance.
+     *
+     * In webauthn-lib 5.3+, passing a PublicKeyCredentialSource to the
+     * validators is deprecated. This method downcasts a stored
+     * PublicKeyCredentialSource to a CredentialRecord so it can be passed to
+     * the validators without triggering deprecation warnings.
+     */
+    public static function toCredentialRecord(CredentialRecord $credential): CredentialRecord
+    {
+        if (! $credential instanceof PublicKeyCredentialSource) {
+            return $credential;
+        }
+
+        return new CredentialRecord(
+            publicKeyCredentialId: $credential->publicKeyCredentialId,
+            type: $credential->type,
+            transports: $credential->transports,
+            attestationType: $credential->attestationType,
+            trustPath: $credential->trustPath,
+            aaguid: $credential->aaguid,
+            credentialPublicKey: $credential->credentialPublicKey,
+            userHandle: $credential->userHandle,
+            counter: $credential->counter,
+            otherUI: $credential->otherUI,
+            backupEligible: $credential->backupEligible,
+            backupStatus: $credential->backupStatus,
+            uvInitialized: $credential->uvInitialized,
+        );
+    }
+
     /**
      * Ensure the given credential is a PublicKeyCredentialSource instance.
      *

--- a/src/Support/PublicKeyCredentialRpEntityDenormalizer.php
+++ b/src/Support/PublicKeyCredentialRpEntityDenormalizer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\LaravelPasskeys\Support;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Webauthn\PublicKeyCredentialRpEntity;
+
+/**
+ * web-auth/webauthn-lib only ships a normalizer for PublicKeyCredentialRpEntity,
+ * so denormalization falls back to Symfony's ObjectNormalizer. That passes the
+ * relying party name to the constructor, which is deprecated since webauthn-lib
+ * 5.3. We denormalize the entity ourselves and assign the name through the
+ * property to avoid the deprecation warning on every passkey registration.
+ */
+class PublicKeyCredentialRpEntityDenormalizer implements DenormalizerInterface
+{
+    /**
+     * @param  array{id?: ?string, name?: ?string}  $data
+     */
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): PublicKeyCredentialRpEntity
+    {
+        $entity = new PublicKeyCredentialRpEntity('', $data['id'] ?? null);
+
+        if (! empty($data['name'])) {
+            $entity->name = $data['name'];
+        }
+
+        return $entity;
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === PublicKeyCredentialRpEntity::class;
+    }
+
+    /**
+     * @return array<class-string, bool>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            PublicKeyCredentialRpEntity::class => true,
+        ];
+    }
+}

--- a/src/Support/Serializer.php
+++ b/src/Support/Serializer.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\LaravelPasskeys\Support;
 
+use ReflectionProperty;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
@@ -14,10 +16,22 @@ class Serializer
     {
         $attestationStatementSupportManager = AttestationStatementSupportManager::create();
 
-        /** @var SymfonySerializer $serializer */
-        $serializer = (new WebauthnSerializerFactory($attestationStatementSupportManager))->create();
+        /** @var SymfonySerializer $webauthnSerializer */
+        $webauthnSerializer = (new WebauthnSerializerFactory($attestationStatementSupportManager))->create();
 
-        return new self($serializer);
+        return new self(static::registerRpEntityDenormalizer($webauthnSerializer));
+    }
+
+    protected static function registerRpEntityDenormalizer(SymfonySerializer $webauthnSerializer): SymfonySerializer
+    {
+        // The factory does not expose its normalizers, so we read them to rebuild
+        // the serializer with our relying party denormalizer taking precedence.
+        $normalizers = (new ReflectionProperty(SymfonySerializer::class, 'normalizers'))->getValue($webauthnSerializer);
+
+        return new SymfonySerializer(
+            [new PublicKeyCredentialRpEntityDenormalizer, ...$normalizers],
+            [new JsonEncoder],
+        );
     }
 
     public function __construct(

--- a/tests/Feature/Support/CredentialRecordConverterTest.php
+++ b/tests/Feature/Support/CredentialRecordConverterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Spatie\LaravelPasskeys\Support\CredentialRecordConverter;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+function aPublicKeyCredentialSource(): PublicKeyCredentialSource
+{
+    return new PublicKeyCredentialSource(
+        'credential-id',
+        PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+        ['internal'],
+        'none',
+        EmptyTrustPath::create(),
+        Uuid::fromString('00000000-0000-0000-0000-000000000000'),
+        'public-key',
+        'user-handle',
+        100,
+    );
+}
+
+it('converts a PublicKeyCredentialSource to a plain CredentialRecord', function () {
+    $credentialRecord = CredentialRecordConverter::toCredentialRecord(aPublicKeyCredentialSource());
+
+    expect($credentialRecord)->toBeInstanceOf(CredentialRecord::class);
+    expect($credentialRecord)->not->toBeInstanceOf(PublicKeyCredentialSource::class);
+});
+
+it('preserves all properties when converting to a CredentialRecord', function () {
+    $source = aPublicKeyCredentialSource();
+
+    $credentialRecord = CredentialRecordConverter::toCredentialRecord($source);
+
+    expect($credentialRecord->publicKeyCredentialId)->toBe($source->publicKeyCredentialId);
+    expect($credentialRecord->type)->toBe($source->type);
+    expect($credentialRecord->transports)->toBe($source->transports);
+    expect($credentialRecord->attestationType)->toBe($source->attestationType);
+    expect($credentialRecord->trustPath)->toBe($source->trustPath);
+    expect($credentialRecord->aaguid)->toBe($source->aaguid);
+    expect($credentialRecord->credentialPublicKey)->toBe($source->credentialPublicKey);
+    expect($credentialRecord->userHandle)->toBe($source->userHandle);
+    expect($credentialRecord->counter)->toBe($source->counter);
+});

--- a/tests/Feature/Support/SerializerTest.php
+++ b/tests/Feature/Support/SerializerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Spatie\LaravelPasskeys\Support\Serializer;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+it('does not trigger a deprecation when deserializing creation options with a relying party name', function () {
+    $relyingPartyEntity = new PublicKeyCredentialRpEntity('', 'localhost');
+    $relyingPartyEntity->name = 'My application';
+
+    $options = new PublicKeyCredentialCreationOptions(
+        rp: $relyingPartyEntity,
+        user: new PublicKeyCredentialUserEntity('john', 'user-id', 'John Doe'),
+        challenge: random_bytes(16),
+        pubKeyCredParams: [],
+    );
+
+    $json = Serializer::make()->toJson($options);
+
+    $deprecations = [];
+    set_error_handler(function (int $level, string $message) use (&$deprecations): bool {
+        $deprecations[] = $message;
+
+        return true;
+    }, E_USER_DEPRECATED);
+
+    try {
+        $deserialized = Serializer::make()->fromJson($json, PublicKeyCredentialCreationOptions::class);
+    } finally {
+        restore_error_handler();
+    }
+
+    expect($deserialized->rp->name)->toBe('My application');
+    expect($deprecations)->toBe([]);
+});


### PR DESCRIPTION
Fixes #121

webauthn-lib 5.3 deprecated passing a `PublicKeyCredentialSource`/`$name` in two spots that the package hit on every passkey login and registration. This removes both.

## Authentication: pass a CredentialRecord to the validator

Passing a `PublicKeyCredentialSource` to `AuthenticatorAssertionResponseValidator::check()` is deprecated; a `CredentialRecord` should be passed instead. The credential then flows through `CeremonyStepManager::process()` and every `CeremonyStep`, each triggering its own deprecation. Because we stored passkeys as `PublicKeyCredentialSource` and passed `$passkey->data` straight into `check()`, every login logged a deprecation for each ceremony step.

`FindPasskeyToAuthenticateAction` now downcasts the stored `PublicKeyCredentialSource` to a plain `CredentialRecord` before calling `check()`, via a new `CredentialRecordConverter::toCredentialRecord()` method. Credentials are still stored as `PublicKeyCredentialSource` (the validator's return value is converted back), so persistence is unchanged.

## Registration: assign the relying party name through the property on deserialize

During registration, `StorePasskeyAction` deserializes the creation options JSON to hand it to the attestation validator. webauthn-lib only ships a normalizer (not a denormalizer) for `PublicKeyCredentialRpEntity`, so Symfony's `ObjectNormalizer` rebuilds the entity through its constructor and passes the relying party name to the deprecated `$name` parameter, logging a warning on every registration.

We register a `PublicKeyCredentialRpEntityDenormalizer` that assigns the name through the property instead, mirroring how `GeneratePasskeyRegisterOptionsAction` already builds the entity.

Both paths are covered by tests asserting no deprecation is triggered.